### PR TITLE
Help Command + Wizard Encounter + Penultimate Encounter + Floor Updates

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -15244,8 +15244,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1360784986}
-  - component: {fileID: 1360784985}
   - component: {fileID: 1360784987}
+  - component: {fileID: 1360784985}
   - component: {fileID: 1360784988}
   - component: {fileID: 1360784989}
   - component: {fileID: 1360784991}
@@ -17259,6 +17259,7 @@ MonoBehaviour:
   inputField: {fileID: 1491552934}
   textArea: {fileID: 684065085}
   carrot: {fileID: 439177096}
+  helpHandler: {fileID: 0}
   colorManager: {fileID: 0}
   cheatCodeManager: {fileID: 0}
   hintText: 
@@ -21819,6 +21820,7 @@ MonoBehaviour:
   inputField: {fileID: 1856952947}
   textArea: {fileID: 278315056}
   carrot: {fileID: 1878140573}
+  helpHandler: {fileID: 2041287937}
   colorManager: {fileID: 2041287936}
   cheatCodeManager: {fileID: 1360784988}
   hintText: 'Lost? Check your <b>Cheats</b> folder to see what cheats you have! Or
@@ -24204,6 +24206,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2041287935}
   - component: {fileID: 2041287936}
+  - component: {fileID: 2041287937}
   m_Layer: 0
   m_Name: Keyword Handlers
   m_TagString: Untagged
@@ -24239,6 +24242,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   colorStore: {fileID: 11400000, guid: eb1034c4958bdfc4ca243e6451901fcc, type: 2}
+--- !u!114 &2041287937
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2041287934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 461329574599b0b4781d4056f91f4b62, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2072455474
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -15460,6 +15460,8 @@ MonoBehaviour:
   - {fileID: 11400000, guid: e025478594f23e14da6ebe71f62a50f9, type: 2}
   - {fileID: 11400000, guid: 8ba8d3710754e394ca54b1355c04b3de, type: 2}
   - {fileID: 11400000, guid: 4159ca27e6cbabf4597913667bd22eff, type: 2}
+  - {fileID: 11400000, guid: b51fde1b0b167c7439f420396e6311b6, type: 2}
+  - {fileID: 11400000, guid: 85d0f3e94bf090f41bedc5a75eb9485c, type: 2}
   nCToCRatio: {x: 1, y: 2}
   chanceToIgnoreRatio: 10
 --- !u!114 &1360784994

--- a/Assets/Scriptable Objects/Encounters/Campfire Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Campfire Encounter.asset
@@ -22,6 +22,9 @@ MonoBehaviour:
   isCombat: 0
   enemySpeedMin: 3
   enemySpeedMax: 7
+  keywords:
+  - rest
+  - leave
   attackDialogues: []
   healAmount: 5
   uses: 3

--- a/Assets/Scriptable Objects/Encounters/Campfire Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Campfire Encounter.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Campfire Encounter
   m_EditorClassIdentifier: 
   description: You notice a light as you enter the room. A campfire blazes but with
-    no one to sit at it. How long has it been buring? Who made it? Where are they?
-    Your body aches as it wants to rest here.
+    no one around it. How long has it been burning? Who made it? Where are they?
+    Your body aches as it wants to <i>rest</i> here; however, it might be safer to
+    <i>leave</i> incase whoever made it returns.
   subjectSprite: {fileID: 0}
   minigame: 0
   encounterName: A Campfire
@@ -31,11 +32,10 @@ MonoBehaviour:
   isEvil: 0
   isSetUp: 0
   restText: The tension in your muscles evaporate as you sit next to the campfire.
-    Its flames are still burning but seem to be dwindling.
-  burnOutText: The once roaring flame disappears into darkness. Nothing remains other
+    Its roaring flames are dwindling.
+  burnOutText: The once roaring flames disappear into darkness. Nothing remains other
     than the charred pieces of firewood. Your torch is your only source of light.
-  ambushText: You look out into the darkness and find something staring back. Is
-    it the one who built the campfire? Before you get your answers, it lunges at
-    you.
+  ambushText: You look out into the darkness and see something staring back. Is it
+    the one who built the campfire? Before you get your answers, it lunges at you.
   leaveText: You leave the campfire alone. Who knows who made it and when they are
     coming back.

--- a/Assets/Scriptable Objects/Encounters/Campfire Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Campfire Encounter.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
     Your body aches as it wants to rest here.
   subjectSprite: {fileID: 0}
   minigame: 0
-  encounterName: Campfire
+  encounterName: A Campfire
   enemyIndex: 0
   isCombat: 0
   enemySpeedMin: 3
@@ -29,6 +29,7 @@ MonoBehaviour:
   healAmount: 5
   uses: 3
   isEvil: 0
+  isSetUp: 0
   restText: The tension in your muscles evaporate as you sit next to the campfire.
     Its flames are still burning but seem to be dwindling.
   burnOutText: The once roaring flame disappears into darkness. Nothing remains other

--- a/Assets/Scriptable Objects/Encounters/Fountain Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Fountain Encounter.asset
@@ -12,8 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 419576b96c9075e4e9a86d272c9948b4, type: 3}
   m_Name: Fountain Encounter
   m_EditorClassIdentifier: 
-  description: 'A fluorescent fuchsia fountain stands in the middle of the room.
-    Its water shimmers in the tourch light. It beckons you to bathe in it. '
+  description: A fluorescent fuchsia fountain stands in the middle of the room. Its
+    water shimmers in the tourch light. It beckons you to <i>bathe</i> in it; though,
+    it may be smater to <i>ignore</i> it.
   subjectSprite: {fileID: 0}
   minigame: 0
   encounterName: A Healing Fountain

--- a/Assets/Scriptable Objects/Encounters/Fountain Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Fountain Encounter.asset
@@ -21,6 +21,9 @@ MonoBehaviour:
   isCombat: 0
   enemySpeedMin: 3
   enemySpeedMax: 7
+  keywords:
+  - bathe
+  - ignore
   attackDialogues: []
   batheString: As the water runs across your skin, you can feel it repair your broken
     body. Your dirty hair shining with a renewed beauty. Your skin smoothening with

--- a/Assets/Scriptable Objects/Encounters/Fountain Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Fountain Encounter.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
     Its water shimmers in the tourch light. It beckons you to bathe in it. '
   subjectSprite: {fileID: 0}
   minigame: 0
-  encounterName: Healing Fountain
+  encounterName: A Healing Fountain
   enemyIndex: 0
   isCombat: 0
   enemySpeedMin: 3

--- a/Assets/Scriptable Objects/Encounters/Horse Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Horse Encounter.asset
@@ -30,11 +30,11 @@ MonoBehaviour:
   - deny
   attackDialogues: []
   baseEvilHorseChance: 10
-  evilHorseChance: 0
+  evilHorseChance: 20
   evilHorseChanceIncrease: 10
   increaseChancePerGoodHorse: 1
   forceEvilHorse: 0
-  isEvil: 0
+  isEvil: 1
   isSetUp: 0
   healthBoostAmount: 5
   damageBoostAmount: 1

--- a/Assets/Scriptable Objects/Encounters/Horse Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Horse Encounter.asset
@@ -23,6 +23,11 @@ MonoBehaviour:
   isCombat: 0
   enemySpeedMin: 3
   enemySpeedMax: 7
+  keywords:
+  - pet
+  - accept
+  - deny
+  - apple
   attackDialogues: []
   baseEvilHorseChance: 10
   evilHorseChance: 50
@@ -33,7 +38,6 @@ MonoBehaviour:
   healthBoostAmount: 5
   damageBoostAmount: 1
   speedBoostAmount: 3
-  typingSpeedBoostAmount: 2
   petResponse:
   - Its fur shines like the dawn of a new day. You can feel the horse's strong muscles
     under its skin. This horse has been well kept.

--- a/Assets/Scriptable Objects/Encounters/Horse Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Horse Encounter.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
     something.
   subjectSprite: {fileID: 0}
   minigame: 0
-  encounterName: Horse Encounter
+  encounterName: A Horse
   enemyIndex: 0
   isCombat: 0
   enemySpeedMin: 3
@@ -30,11 +30,12 @@ MonoBehaviour:
   - apple
   attackDialogues: []
   baseEvilHorseChance: 10
-  evilHorseChance: 50
+  evilHorseChance: 20
   evilHorseChanceIncrease: 10
   increaseChancePerGoodHorse: 1
   forceEvilHorse: 0
-  isEvil: 0
+  isEvil: 1
+  isSetUp: 0
   healthBoostAmount: 5
   damageBoostAmount: 1
   speedBoostAmount: 3

--- a/Assets/Scriptable Objects/Encounters/Horse Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Horse Encounter.asset
@@ -15,7 +15,8 @@ MonoBehaviour:
   description: A horse stands alone in the center of the room. A saddle sits on its
     back, but its rider is no where to be found. There are no signs of its rider
     ever coming back. The horse stares into your eyes as if it wants to give you
-    something.
+    something. <i>Pet</i>ting the horse may let you know it better. Do you <i>accept</i>
+    or <i>deny</i> the horse's request?
   subjectSprite: {fileID: 0}
   minigame: 0
   encounterName: A Horse
@@ -27,14 +28,13 @@ MonoBehaviour:
   - pet
   - accept
   - deny
-  - apple
   attackDialogues: []
   baseEvilHorseChance: 10
-  evilHorseChance: 20
+  evilHorseChance: 0
   evilHorseChanceIncrease: 10
   increaseChancePerGoodHorse: 1
   forceEvilHorse: 0
-  isEvil: 1
+  isEvil: 0
   isSetUp: 0
   healthBoostAmount: 5
   damageBoostAmount: 1
@@ -68,6 +68,8 @@ MonoBehaviour:
   evilHorseDeny: As you walk away, the horse stares with sadness in its eyes. A malice
     pierces the horse's dispair.
   goodHorseAccept: The horse guides you to its old owner's pouch. It is offering
-    the belongings of its previous owner.
+    the belongings of its previous owner. You take this as a sign that its previous
+    owner doesn't need their stuff anymore. You take what you need, thank the horse,
+    and move on.
   goodHorseDeny: As you walk away, the horse stares with sadness in its eyes. Its
     dispair grows into grief.

--- a/Assets/Scriptable Objects/Encounters/Library Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Library Encounter.asset
@@ -41,6 +41,8 @@ MonoBehaviour:
   ignoreText: You hear pages turn as you walk past the pedestal; however, the book
     is gone when you turn around. The pedestal is topped with dust as if the book
     was never there. "Strange," you think before moving on.
+  waiting: 0
+  ignoring: 0
   damage: 1
   speedLost: 5
   typingSpeedLost: 1

--- a/Assets/Scriptable Objects/Encounters/Library Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Library Encounter.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
     nose. Ancient books line the walls and stack on top of each other as far as the
     eye can see. Who knows what ancience secrets this library stores. In the middle
     of the library sits a book upon a pedestal. It is written in a language you have
-    never seen before. <b>Read</b> it or <b>ignore</b> it?
+    never seen before. <i>Read</i> it or <i>ignore</i> it?
   subjectSprite: {fileID: 0}
   minigame: 10
   encounterName: A Library

--- a/Assets/Scriptable Objects/Encounters/Library Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Library Encounter.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     never seen before. <b>Read</b> it or <b>ignore</b> it?
   subjectSprite: {fileID: 0}
   minigame: 10
-  encounterName: 
+  encounterName: A Library
   enemyIndex: 0
   isCombat: 0
   enemySpeedMin: 3
@@ -42,7 +42,6 @@ MonoBehaviour:
     is gone when you turn around. The pedestal is topped with dust as if the book
     was never there. "Strange," you think before moving on.
   waiting: 0
-  ignoring: 0
   damage: 1
   speedLost: 5
   typingSpeedLost: 1

--- a/Assets/Scriptable Objects/Encounters/Library Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Library Encounter.asset
@@ -24,6 +24,9 @@ MonoBehaviour:
   isCombat: 0
   enemySpeedMin: 3
   enemySpeedMax: 7
+  keywords:
+  - read
+  - ignore
   attackDialogues: []
   waitBeforeReadingBook: 3
   readText: You peer into the words written on the page. The symbols are plastered

--- a/Assets/Scriptable Objects/Encounters/Penultimate Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Penultimate Encounter.asset
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 47e5bbc22f217284b9bebe27a1d91c45, type: 3}
+  m_Name: Penultimate Encounter
+  m_EditorClassIdentifier: 
+  description: You shouldn't be seeing this description.
+  subjectSprite: {fileID: 0}
+  minigame: 0
+  encounterName: An End
+  enemyIndex: 0
+  isCombat: 0
+  enemySpeedMin: 3
+  enemySpeedMax: 7
+  keywords:
+  - <color=#ff000099>noclip</color>
+  attackDialogues: []
+  noclipResponse: After uttering that word, you place your hand on the wall... and
+    miss. Your hand went through the wall. You push the rest of your body through
+    the wall. A corridor awaits on the other side.
+  descriptions:
+  - Your heart sinks as you approach a wall. The path forward has been cut off. Looking
+    back, all you see is the darkness of the void. You can hear the scuttering of
+    the creatures you came across and the ones you have not seen. All paths lead
+    to this point. No way this is the end of the dungeon.
+  - Upon closer inspection, you see a constant stream of dust pouring from the wall.
+    Occasionally more dust falls out of the wall as if it was breathing.
+  - You put your face against the wall. It's warm. The warm air of the wall classes
+    with the permafrost air of the dungeon. There is something wrong with this wall.
+  - You slam your tools against the wall. Nothing. You try again; harder this time.
+    Nothing. You try with all your might. Nothing. It is as if this world only responds
+    to the things it wants you to do. What it wants from you is unknown to you, but
+    not <color=#ff0000>you.</color>
+  - <i>N</i>othing y<i>o</i>u try is getting you <i>c</i>loser to the end. It is
+    as if <i>l</i>ife doesn't want you to continue. Even <i>i</i>f there was a route
+    around, who knows what horrors occu<i>p</i>y this dungeon.
+  descriptionIndex: -1
+  isSetUp: 0

--- a/Assets/Scriptable Objects/Encounters/Penultimate Encounter.asset.meta
+++ b/Assets/Scriptable Objects/Encounters/Penultimate Encounter.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7f436d416ff0b7140b4633c37b941610
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scriptable Objects/Encounters/Trap Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Trap Encounter.asset
@@ -17,15 +17,18 @@ MonoBehaviour:
     You struggle to set your leg free.
   subjectSprite: {fileID: 0}
   minigame: 2
-  encounterName: 
+  encounterName: A Trap
   enemyIndex: 0
   isCombat: 0
   enemySpeedMin: 3
   enemySpeedMax: 7
+  keywords: []
   attackDialogues: []
+  trapDelay: 3
   speedLoss: 5
   damage: 5
   failureResponse: You fail to open the trap. Out of options, you pull out your leg
     with all your might. Your leg flies out of the trap bruised and injured.
   successResponse: You free your leg from the trap. Luckly the metal bars didn't
     shut too tight. You are relatively unscathed.
+  isSetUp: 0

--- a/Assets/Scriptable Objects/Encounters/Wizard Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Wizard Encounter.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
     stands in the middle of the room staring into a glossy white orb. Without turning
     to face you, the man says, "this orb sees the secrets of your future. Only those
     skilled in the arcane arts can look into it. If you know them, you may want to
-    <b>chant</b> with me. Otherwise, it would be smarter to <b>pass</b> by."
+    <i>chant</i> with me. Otherwise, it would be smarter to <i>pass</i> by."
   subjectSprite: {fileID: 0}
   minigame: 8
   encounterName: A Wizard

--- a/Assets/Scriptable Objects/Encounters/Wizard Encounter.asset
+++ b/Assets/Scriptable Objects/Encounters/Wizard Encounter.asset
@@ -1,0 +1,52 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8010927fc9b56904d84eaf376e5bc19e, type: 3}
+  m_Name: Wizard Encounter
+  m_EditorClassIdentifier: 
+  description: The walls are lined with jars of unknown substances. Books of arcane
+    writings line the floor. A man with an overgrown beard and a sharp pointed hat
+    stands in the middle of the room staring into a glossy white orb. Without turning
+    to face you, the man says, "this orb sees the secrets of your future. Only those
+    skilled in the arcane arts can look into it. If you know them, you may want to
+    <b>chant</b> with me. Otherwise, it would be smarter to <b>pass</b> by."
+  subjectSprite: {fileID: 0}
+  minigame: 8
+  encounterName: A Wizard
+  enemyIndex: 0
+  isCombat: 0
+  enemySpeedMin: 3
+  enemySpeedMax: 7
+  keywords:
+  - chant
+  - pass
+  attackDialogues: []
+  chantWait: 3
+  chantText: Though still not facing you, you can see the man's ears perk up. "You
+    are a brave one to be sure," the man says, "but are you a smart one?"
+  ignoreText: You walk past the man. Before leaving the room, you turn around. Nothing.
+    As if he was never there. You shrug off this unconventional encounter and leave
+    the room.
+  smokeText: You reach into your bag and pull out your greatest tobacco. The man
+    turns around and smiles. After a few hours, the man tells you, "I have not had
+    something like this for a long time."
+  chantPassText: The man tells you, "I believe you are worthy to search the orb."
+    You approach the orb. "Look deep into it, and it will tell you what you need
+    to hear," the man whispers to you. You turn around to look at him, but he is
+    no where to be seen. With nothing else to do, you stare deep into the orb.
+  chantFailText: The man lets out a hearty laugh, "only fools take on challenges
+    they are unmatched for!" You start to feel dizzy. Did you say something wrong?
+    Did you accidentally curse yourself? For a moment, your vision blurs. When your
+    vision returns, the man is gone. The orb has losts its luster. It's nothing more
+    than a decoration now. With nothing else to do, you leave the room.
+  speedLost: 10
+  typingSpeedLost: 5
+  damage: 10

--- a/Assets/Scriptable Objects/Encounters/Wizard Encounter.asset.meta
+++ b/Assets/Scriptable Objects/Encounters/Wizard Encounter.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 85d0f3e94bf090f41bedc5a75eb9485c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scriptable Objects/Floor 1/f1_1_r0.asset
+++ b/Assets/Scriptable Objects/Floor 1/f1_1_r0.asset
@@ -16,5 +16,6 @@ MonoBehaviour:
   - direction: forward
     destination: {fileID: 11400000, guid: d6b91a6bddb695e4b892fd43c244dbae, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 8ba8d3710754e394ca54b1355c04b3de, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 1/f1_4_l2.asset
+++ b/Assets/Scriptable Objects/Floor 1/f1_4_l2.asset
@@ -14,9 +14,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: left
-    destination: {fileID: 11400000, guid: c3ac86944d669fd429739b24ef619ac9, type: 2}
+    destination: {fileID: 11400000, guid: 5f9e5e5006b80a649bb975a0eedcbf23, type: 2}
   - direction: right
-    destination: {fileID: 11400000, guid: 1d5998b375486cc42850b0e8c7df7326, type: 2}
+    destination: {fileID: 11400000, guid: 9fcd9a2709a4be94fb7c0d66b5ef3a2d, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 0e05e3b854702004e9b09992e394584f, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 1/f1_4_r0.asset
+++ b/Assets/Scriptable Objects/Floor 1/f1_4_r0.asset
@@ -14,9 +14,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: left
-    destination: {fileID: 11400000, guid: 1d5998b375486cc42850b0e8c7df7326, type: 2}
+    destination: {fileID: 11400000, guid: 5f9e5e5006b80a649bb975a0eedcbf23, type: 2}
   - direction: right
-    destination: {fileID: 11400000, guid: 41379678d363f924ca9baf21dab808e9, type: 2}
+    destination: {fileID: 11400000, guid: 9fcd9a2709a4be94fb7c0d66b5ef3a2d, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: e025478594f23e14da6ebe71f62a50f9, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 1/f1_4_r1.asset
+++ b/Assets/Scriptable Objects/Floor 1/f1_4_r1.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: forward
-    destination: {fileID: 11400000, guid: 41379678d363f924ca9baf21dab808e9, type: 2}
+    destination: {fileID: 11400000, guid: 9fcd9a2709a4be94fb7c0d66b5ef3a2d, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 0e05e3b854702004e9b09992e394584f, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 1/f1_7_l3.asset
+++ b/Assets/Scriptable Objects/Floor 1/f1_7_l3.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: forward
-    destination: {fileID: 11400000, guid: da70221d819918d4cbe896fe9cd3b754, type: 2}
+    destination: {fileID: 11400000, guid: d88e2e00c5830e042a85d9f937f25113, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: b51fde1b0b167c7439f420396e6311b6, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 1/f1_7_r1.asset
+++ b/Assets/Scriptable Objects/Floor 1/f1_7_r1.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: forward
-    destination: {fileID: 11400000, guid: da70221d819918d4cbe896fe9cd3b754, type: 2}
+    destination: {fileID: 11400000, guid: d88e2e00c5830e042a85d9f937f25113, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 0e05e3b854702004e9b09992e394584f, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 1/f1_e_r0.asset
+++ b/Assets/Scriptable Objects/Floor 1/f1_e_r0.asset
@@ -15,5 +15,7 @@ MonoBehaviour:
   routes: []
   image: {fileID: 0}
   encounter: {fileID: 0}
-  noEncounterString: This room is empty. You are safe.
+  noEncounterString: As you make it to the end of the first floor of the dungeon,
+    you find yourself staring down a never ending stair case. What wonders await
+    you? What horrors? The only way to know is to climb <color=#ff0000>down</color>.
   allowEncounterChange: 0

--- a/Assets/Scriptable Objects/Floor 1/f1_s_r0.asset
+++ b/Assets/Scriptable Objects/Floor 1/f1_s_r0.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: forward
-    destination: {fileID: 11400000, guid: 14eac94e7fb95ba4cbea116c50ea2eb7, type: 2}
+    destination: {fileID: 11400000, guid: d6b91a6bddb695e4b892fd43c244dbae, type: 2}
   image: {fileID: 0}
   encounter: {fileID: 0}
   noEncounterString: You take your first steps into the dungeon. The cold and stale

--- a/Assets/Scriptable Objects/Floor 2/f2_3_l1.asset
+++ b/Assets/Scriptable Objects/Floor 2/f2_3_l1.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: forward
-    destination: {fileID: 11400000, guid: fba52533be7994844b9a62d8b51e146d, type: 2}
+    destination: {fileID: 11400000, guid: 586d35068d9b8144e8f1667cca19d5e8, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: e025478594f23e14da6ebe71f62a50f9, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 2/f2_3_r0.asset
+++ b/Assets/Scriptable Objects/Floor 2/f2_3_r0.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: forward
-    destination: {fileID: 11400000, guid: e68c513fd839241419c34eebc46b4cfa, type: 2}
+    destination: {fileID: 11400000, guid: 432a03c6057a30844b75f385fa75eb85, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 41e4f0b878d90e34dbc9f49104b13577, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 2/f2_3_r2.asset
+++ b/Assets/Scriptable Objects/Floor 2/f2_3_r2.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: forward
-    destination: {fileID: 11400000, guid: ba0d809783e2ae947b126aff1b300cea, type: 2}
+    destination: {fileID: 11400000, guid: 00a057bd8a5e8174f80cf9dd64d0330c, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 0e05e3b854702004e9b09992e394584f, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 2/f2_6_l1.asset
+++ b/Assets/Scriptable Objects/Floor 2/f2_6_l1.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: forward
-    destination: {fileID: 11400000, guid: e7da3cc1de773a0489b927bd9f8c5384, type: 2}
+    destination: {fileID: 11400000, guid: 44665fa5213536e4ab93d27403c634e1, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 41e4f0b878d90e34dbc9f49104b13577, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 2/f2_6_r0.asset
+++ b/Assets/Scriptable Objects/Floor 2/f2_6_r0.asset
@@ -13,10 +13,9 @@ MonoBehaviour:
   m_Name: f2_6_r0
   m_EditorClassIdentifier: 
   routes:
-  - direction: left
-    destination: {fileID: 11400000, guid: e7da3cc1de773a0489b927bd9f8c5384, type: 2}
-  - direction: right
-    destination: {fileID: 11400000, guid: 9c0b3510d79d03f40bb9d2008c45958d, type: 2}
+  - direction: forward
+    destination: {fileID: 11400000, guid: 44665fa5213536e4ab93d27403c634e1, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 8ba8d3710754e394ca54b1355c04b3de, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 2/f2_6_r1.asset
+++ b/Assets/Scriptable Objects/Floor 2/f2_6_r1.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: forward
-    destination: {fileID: 11400000, guid: 9c0b3510d79d03f40bb9d2008c45958d, type: 2}
+    destination: {fileID: 11400000, guid: 44665fa5213536e4ab93d27403c634e1, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 0e05e3b854702004e9b09992e394584f, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 2/f2_e_r0.asset
+++ b/Assets/Scriptable Objects/Floor 2/f2_e_r0.asset
@@ -15,5 +15,8 @@ MonoBehaviour:
   routes: []
   image: {fileID: 0}
   encounter: {fileID: 0}
-  noEncounterString: This room is empty. You are safe.
+  noEncounterString: You approach another staircase. This one is just as foreboding
+    as before. The listless whisper of air rising out of the dungeon echo through
+    the staricase. You think to youself that you should follow the way of the wind,
+    but you recollect your nerve and prepare to go further <color=#ff0000>down</color>.
   allowEncounterChange: 0

--- a/Assets/Scriptable Objects/Floor 3/f3_2_l1.asset
+++ b/Assets/Scriptable Objects/Floor 3/f3_2_l1.asset
@@ -14,11 +14,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: left
-    destination: {fileID: 11400000, guid: 050806dbefe8c1d49a1b52465f941ed4, type: 2}
+    destination: {fileID: 11400000, guid: 4fc7978f97db4f74880fd4a5ab1d0dc4, type: 2}
   - direction: forward
-    destination: {fileID: 11400000, guid: 952f1418c4f527a429db7c210eeac33a, type: 2}
+    destination: {fileID: 11400000, guid: b4a9e137ad77b3042b57df4ea602ca62, type: 2}
   - direction: right
-    destination: {fileID: 11400000, guid: 9fbfeca0cd599004695100c1d8613255, type: 2}
+    destination: {fileID: 11400000, guid: 70caddfd3f635aa4aa30ef5aaf5a7f81, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 0e05e3b854702004e9b09992e394584f, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 3/f3_2_l2.asset
+++ b/Assets/Scriptable Objects/Floor 3/f3_2_l2.asset
@@ -14,9 +14,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: left
-    destination: {fileID: 11400000, guid: 050806dbefe8c1d49a1b52465f941ed4, type: 2}
+    destination: {fileID: 11400000, guid: 4fc7978f97db4f74880fd4a5ab1d0dc4, type: 2}
   - direction: right
-    destination: {fileID: 11400000, guid: 952f1418c4f527a429db7c210eeac33a, type: 2}
+    destination: {fileID: 11400000, guid: b4a9e137ad77b3042b57df4ea602ca62, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 8ba8d3710754e394ca54b1355c04b3de, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 3/f3_2_r0.asset
+++ b/Assets/Scriptable Objects/Floor 3/f3_2_r0.asset
@@ -14,11 +14,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: left
-    destination: {fileID: 11400000, guid: 952f1418c4f527a429db7c210eeac33a, type: 2}
+    destination: {fileID: 11400000, guid: b4a9e137ad77b3042b57df4ea602ca62, type: 2}
   - direction: forward
-    destination: {fileID: 11400000, guid: 9fbfeca0cd599004695100c1d8613255, type: 2}
+    destination: {fileID: 11400000, guid: 70caddfd3f635aa4aa30ef5aaf5a7f81, type: 2}
   - direction: right
-    destination: {fileID: 11400000, guid: cd5c8470ecf58144383c1c4395dc7df9, type: 2}
+    destination: {fileID: 11400000, guid: ce42d6468d648f044b8f4697eb5c2679, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 0e05e3b854702004e9b09992e394584f, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 3/f3_2_r1.asset
+++ b/Assets/Scriptable Objects/Floor 3/f3_2_r1.asset
@@ -14,11 +14,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: left
-    destination: {fileID: 11400000, guid: 9fbfeca0cd599004695100c1d8613255, type: 2}
+    destination: {fileID: 11400000, guid: 70caddfd3f635aa4aa30ef5aaf5a7f81, type: 2}
   - direction: forward
-    destination: {fileID: 11400000}
+    destination: {fileID: 11400000, guid: ce42d6468d648f044b8f4697eb5c2679, type: 2}
   - direction: right
-    destination: {fileID: 11400000, guid: 798ebbf633bea9d44991c450505b48fd, type: 2}
+    destination: {fileID: 11400000, guid: aafb21f5b4ee9e2479986e7f6284f192, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 0e05e3b854702004e9b09992e394584f, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 3/f3_2_r2.asset
+++ b/Assets/Scriptable Objects/Floor 3/f3_2_r2.asset
@@ -14,9 +14,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: left
-    destination: {fileID: 11400000, guid: cd5c8470ecf58144383c1c4395dc7df9, type: 2}
+    destination: {fileID: 11400000, guid: ce42d6468d648f044b8f4697eb5c2679, type: 2}
   - direction: right
-    destination: {fileID: 11400000, guid: 798ebbf633bea9d44991c450505b48fd, type: 2}
+    destination: {fileID: 11400000, guid: aafb21f5b4ee9e2479986e7f6284f192, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 0e05e3b854702004e9b09992e394584f, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Floor 3/f3_6_r0.asset
+++ b/Assets/Scriptable Objects/Floor 3/f3_6_r0.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   routes:
   - direction: forward
-    destination: {fileID: 11400000, guid: 315ee56a91648b94582b8cca65d9e52d, type: 2}
+    destination: {fileID: 11400000, guid: b6fcb5f07f7c4544495ade4d932399a4, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 7f436d416ff0b7140b4633c37b941610, type: 2}
   noEncounterString: This room is empty. You are safe.
+  allowEncounterChange: 0

--- a/Assets/Scriptable Objects/Floor 3/f3_7_r0.asset
+++ b/Assets/Scriptable Objects/Floor 3/f3_7_r0.asset
@@ -16,5 +16,7 @@ MonoBehaviour:
   - direction: forward
     destination: {fileID: 11400000, guid: b6fcb5f07f7c4544495ade4d932399a4, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
-  noEncounterString: This room is empty. You are safe.
+  encounter: {fileID: 11400000, guid: 7f436d416ff0b7140b4633c37b941610, type: 2}
+  noEncounterString: An empty corridor behind an unpassable wall. You wonder what
+    is lying at the end of it.
+  allowEncounterChange: 0

--- a/Assets/Scriptable Objects/Test Points of Interest/POI - 2.asset
+++ b/Assets/Scriptable Objects/Test Points of Interest/POI - 2.asset
@@ -20,6 +20,6 @@ MonoBehaviour:
   - direction: right
     destination: {fileID: 11400000, guid: a6544291a262a8b4dabe644ef3ebcd7a, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 11400000, guid: b51fde1b0b167c7439f420396e6311b6, type: 2}
+  encounter: {fileID: 11400000, guid: 85d0f3e94bf090f41bedc5a75eb9485c, type: 2}
   noEncounterString: This room is empty. You are safe.
   allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Test Points of Interest/POI - 2.asset
+++ b/Assets/Scriptable Objects/Test Points of Interest/POI - 2.asset
@@ -20,6 +20,6 @@ MonoBehaviour:
   - direction: right
     destination: {fileID: 11400000, guid: a6544291a262a8b4dabe644ef3ebcd7a, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 11400000, guid: 41e4f0b878d90e34dbc9f49104b13577, type: 2}
+  encounter: {fileID: 11400000, guid: 85d0f3e94bf090f41bedc5a75eb9485c, type: 2}
   noEncounterString: This room is empty. You are safe.
   allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Test Points of Interest/POI - 2.asset
+++ b/Assets/Scriptable Objects/Test Points of Interest/POI - 2.asset
@@ -20,6 +20,6 @@ MonoBehaviour:
   - direction: right
     destination: {fileID: 11400000, guid: a6544291a262a8b4dabe644ef3ebcd7a, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 11400000, guid: 85d0f3e94bf090f41bedc5a75eb9485c, type: 2}
+  encounter: {fileID: 11400000, guid: 41e4f0b878d90e34dbc9f49104b13577, type: 2}
   noEncounterString: This room is empty. You are safe.
   allowEncounterChange: 1

--- a/Assets/Scriptable Objects/Test Points of Interest/POI - 3.asset
+++ b/Assets/Scriptable Objects/Test Points of Interest/POI - 3.asset
@@ -20,6 +20,6 @@ MonoBehaviour:
   - direction: left
     destination: {fileID: 11400000, guid: c922461baaf39a54c914cb3f4d4ead77, type: 2}
   image: {fileID: 0}
-  encounter: {fileID: 0}
+  encounter: {fileID: 11400000, guid: 7f436d416ff0b7140b4633c37b941610, type: 2}
   noEncounterString: This room is empty. You are safe.
   allowEncounterChange: 1

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -110,15 +110,15 @@ public class GameManager : MonoBehaviour
         CheckEncounterType(); // Check the encounter type after moving
 
         //Routes need to be prompted *after* description, so just wait a frame. Spaghetti code at its finest.
-        if (!inEncounter) StartCoroutine(PromptRoutesAfterMove()); 
+        if (!inEncounter) StartCoroutine(PromptRoutesNextFrame()); 
         return currentPOI.GetDescription();
     }
 
     /// <summary>
-    /// Just ot make sure route prompts appear after description after moving into a safe room.
+    /// Prompting Routes mess a lot of things up, so just wait until everything is done this frame and do the routes next frame.
     /// </summary>
     /// <returns></returns>
-    IEnumerator PromptRoutesAfterMove()
+    IEnumerator PromptRoutesNextFrame()
     {
         yield return null;
         PromptRoutes();
@@ -139,7 +139,7 @@ public class GameManager : MonoBehaviour
     public void LeaveEnounter()
     {
         inEncounter = false;
-        PromptRoutes();
+        StartCoroutine(PromptRoutesNextFrame());
     }
 
     /// <summary>

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -54,6 +54,24 @@ public class GameManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Gets all keywords to be shown to the player.
+    /// </summary>
+    /// <returns>A list of keywords.</returns>
+    public List<string> GetKeywords()
+    {
+        List<string> response = currentPOI.GetPOIKeywords();
+        if(response == null) response = new List<string>();
+
+        //These keywords are found in the InputParser.
+        //They're defined here due to the natural flow from Encounter -> POI -> GameManager due their these object's relationships.
+        //The code is noodling as we speak.
+        response.Add("move");
+        response.Add("color");
+
+        return response;
+    }
+
+    /// <summary>
     /// Checks if current <see cref="PointOfInterest"/> or current POI's <see cref="Encounter"/> can parse the input.
     /// </summary>
     /// <param name="tokens">Tokens from player input.</param>
@@ -213,7 +231,4 @@ public class GameManager : MonoBehaviour
             Debug.Log("GameManager: Non-combat encounter.");
         }
     }
-
-
-
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -45,6 +45,15 @@ public class GameManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Gets the routes of the current POI.
+    /// </summary>
+    /// <returns></returns>
+    public List<Route> GetCurrentPOIRoutes()
+    {
+        return currentPOI.GetRoutes();
+    }
+
+    /// <summary>
     /// Gets current <see cref="PointOfInterest"/> image.
     /// </summary>
     /// <returns>The sprite of the current <see cref="PointOfInterest"/></returns>

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -98,7 +98,7 @@ public class GameManager : MonoBehaviour
     /// <returns>The description of the new <see cref="PointOfInterest"/> or a line stating move failure.</returns>
     public string AttemptMove(string[] tokens)
     {
-        if (tokens.Length == 1) return "Usage: move <direction>\ndirection designates which route you want to go down.";
+        if (tokens.Length == 1) return "Usage: move <direction>\ndirection: designates which route you want to go down.";
 
         if (inEncounter /*&& !noclipped*/) return "You cannot leave in the middle of an encounter!";
 

--- a/Assets/Scripts/Input-Output/InputParser.cs
+++ b/Assets/Scripts/Input-Output/InputParser.cs
@@ -15,6 +15,7 @@ public class InputParser : MonoBehaviour
     [SerializeField] protected GameObject carrot;
 
     [Header("Keyword Handlers")]
+    [SerializeField] HelpHandler helpHandler;
     [SerializeField] ColorManager colorManager;
     [SerializeField] CheatCodeManager cheatCodeManager;
 
@@ -87,6 +88,7 @@ public class InputParser : MonoBehaviour
     /// <param name="input">The input entered in the inputField</param>
     public virtual void ParseInput(string input)
     {
+        //When adding keywords to the InputParser itself, don't forget to update the GetKeywords in GameManager.
         if (string.IsNullOrEmpty(input)) return;
 
         TextOutput.instance.Print($"{input}", OutputCarrot.USER); // Prefix user input with user carrot
@@ -112,6 +114,9 @@ public class InputParser : MonoBehaviour
                     break;
                 case "move":
                     output = GameManager.instance.AttemptMove(tokens);
+                    break;
+                case "help":
+                    output = helpHandler.ReadTokens(tokens);
                     break;
                 case "godmode":
                     cheatCodeManager.TryActivateCheat("GodMode");

--- a/Assets/Scripts/Keyword Handlers/HelpHandler.cs
+++ b/Assets/Scripts/Keyword Handlers/HelpHandler.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+/// <summary>
+/// HelpHandler is a <see cref="KeywordHandler"/> that collects
+/// the current keywords and sets them up for the player.
+/// </summary>
+public class HelpHandler : KeywordHandler
+{
+    public override string ReadTokens(string[] tokens)
+    {
+        List<string> keywords = GameManager.instance.GetKeywords();
+        StringBuilder response = new StringBuilder("Available Keywords:\n");
+        foreach (string keyword in keywords)
+        {
+            response.Append($"-{keyword}\n");
+        }
+        response.Append("For keywords that have more than one argument, enter the keyword to see its usage.");
+
+        return response.ToString();
+    }
+}

--- a/Assets/Scripts/Keyword Handlers/HelpHandler.cs.meta
+++ b/Assets/Scripts/Keyword Handlers/HelpHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 461329574599b0b4781d4056f91f4b62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Point Of Interest/Encounters/CampfireEncounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/CampfireEncounter.cs
@@ -98,7 +98,7 @@ public class CampfireEncounter : Encounter
             return ambushText;
         }
 
-        GameManager.instance.LeaveEnounter();
+        LeaveEncounter();
         return burnOutText;
     }
 
@@ -108,7 +108,7 @@ public class CampfireEncounter : Encounter
     /// <returns>Response to leaving.</returns>
     private string Leave()
     {
-        GameManager.instance.LeaveEnounter();
+        LeaveEncounter();
         return leaveText;
     }
 

--- a/Assets/Scripts/Point Of Interest/Encounters/CampfireEncounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/CampfireEncounter.cs
@@ -17,7 +17,7 @@ public class CampfireEncounter : Encounter
     [SerializeField] int uses = 3;
     int usesLeft;
     [SerializeField] bool isEvil;
-    bool isSetUp = false;
+    [SerializeField] bool isSetUp = false; //Serialized for debugging
 
     [Header("Campfire Flavor")]
     [TextArea(3, 10)] [SerializeField] string restText;

--- a/Assets/Scripts/Point Of Interest/Encounters/Encounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/Encounter.cs
@@ -112,7 +112,9 @@ public class Encounter : ScriptableObject, MinigameCaller
     /// <returns>The list of keywords.</returns>
     public virtual List<string> GetEncounterKeywords()
     {
-        return keywords;
+        List<string> ans = new List<string>();
+        ans.AddRange(keywords);
+        return ans;
     }
 
     /// <summary>

--- a/Assets/Scripts/Point Of Interest/Encounters/Encounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/Encounter.cs
@@ -106,6 +106,16 @@ public class Encounter : ScriptableObject, MinigameCaller
     }
 
     /// <summary>
+    /// Gets keywords of the specific encounter to be shown to the player.
+    /// </summary>
+    /// <returns>The list of keywords.</returns>
+    public virtual List<string> GetEncounterKeywords()
+    {
+        //"continue" and "play" are test keywords and are not for actual use. "godmode" is a cheat code and shouldn't be shown to the player.
+        return null;
+    }
+
+    /// <summary>
     /// Checks if encounter can handle player's input.
     /// </summary>
     /// <param name="tokens">Tokens from player input.</param>

--- a/Assets/Scripts/Point Of Interest/Encounters/Encounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/Encounter.cs
@@ -20,6 +20,7 @@ public class Encounter : ScriptableObject, MinigameCaller
     [SerializeField] bool isCombat; // Whether this is a combat encounter
     [SerializeField] int enemySpeedMin = 3; // Minimum speed of the enemy
     [SerializeField] int enemySpeedMax = 7; // Maximum speed of the enemy
+    [SerializeField] List<string> keywords = new List<string>(); //Only to be shown to the player.
 
     [Header("Enemy Attack Dialogue")]
     [SerializeField] List<string> attackDialogues = new List<string>(); // List of attack dialogues
@@ -111,8 +112,7 @@ public class Encounter : ScriptableObject, MinigameCaller
     /// <returns>The list of keywords.</returns>
     public virtual List<string> GetEncounterKeywords()
     {
-        //"continue" and "play" are test keywords and are not for actual use. "godmode" is a cheat code and shouldn't be shown to the player.
-        return null;
+        return keywords;
     }
 
     /// <summary>

--- a/Assets/Scripts/Point Of Interest/Encounters/HorseEncounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/HorseEncounter.cs
@@ -21,7 +21,7 @@ public class HorseEncounter : Encounter
     [SerializeField] bool increaseChancePerGoodHorse = true;
     [SerializeField] bool forceEvilHorse = false;
     [SerializeField] bool isEvil = false;
-    bool isSetUp = false;
+    [SerializeField] bool isSetUp = false;
 
     [Header("Good Horse Outcomes")]
     [SerializeField] int healthBoostAmount = 5;

--- a/Assets/Scripts/Point Of Interest/Encounters/HorseEncounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/HorseEncounter.cs
@@ -140,6 +140,9 @@ public class HorseEncounter : Encounter
         int response = evilHorseChance / 10;
         if (response < 0) response = 0;
         else if(response >= petResponse.Count) response = petResponse.Count - 1;
+        string output = petResponse[response];
+
+        if (isEvil) return $"{output} Something urks you.";
         return petResponse[response];
     }
 

--- a/Assets/Scripts/Point Of Interest/Encounters/LibraryEncounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/LibraryEncounter.cs
@@ -20,7 +20,6 @@ public class LibraryEncounter : Encounter, Waiter
     [TextArea(3, 10)][SerializeField] string readFailure;
     [TextArea(3, 10)][SerializeField] string ignoreText;
     [SerializeField] bool waiting = false; //To make sure the player cannot enter any keywords during the reading wainting period.
-    [SerializeField] bool ignoring = false;
 
     [Header("Minigame Failure Punishments")]
     [SerializeField] int damage = 1;
@@ -29,7 +28,6 @@ public class LibraryEncounter : Encounter, Waiter
 
     private void OnDisable()
     {
-        ignoring = false;
         waiting = false;
     }
 
@@ -125,23 +123,8 @@ public class LibraryEncounter : Encounter, Waiter
     /// <returns>Null for spahgetti nonsense</returns>
     private string Ignore()
     {
-        //Route prompt appeared before ignore text. So this is why this is so round about.
-        ignoring = true;
         LeaveEncounter();
-        return null;
-    }
-
-    /// <summary>
-    /// Prints ignore text and then leaves encounter.
-    /// </summary>
-    public override void LeaveEncounter()
-    {
-        if(ignoring)
-        {
-            ignoring = false;
-            TextOutput.instance.Print(ignoreText);
-        }
-        base.LeaveEncounter();
+        return ignoreText;
     }
 
     public void WaitComplete()

--- a/Assets/Scripts/Point Of Interest/Encounters/LibraryEncounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/LibraryEncounter.cs
@@ -19,8 +19,8 @@ public class LibraryEncounter : Encounter, Waiter
     [TextArea(3, 10)][SerializeField] string readSuccess;
     [TextArea(3, 10)][SerializeField] string readFailure;
     [TextArea(3, 10)][SerializeField] string ignoreText;
-    bool waiting = false; //To make sure the player cannot enter any keywords during the reading wainting period.
-    bool ignoring = false;
+    [SerializeField] bool waiting = false; //To make sure the player cannot enter any keywords during the reading wainting period.
+    [SerializeField] bool ignoring = false;
 
     [Header("Minigame Failure Punishments")]
     [SerializeField] int damage = 1;

--- a/Assets/Scripts/Point Of Interest/Encounters/PenultimateEncounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/PenultimateEncounter.cs
@@ -1,0 +1,79 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// PenultimateEncounter is a noncombat <see cref="Encounter"/>.
+/// It pretends that it is a deadend and forces the player to use a 
+/// special case of noclip to proceed. Meant to be used for the second
+/// to last room in the game hence the name.
+/// </summary>
+[CreateAssetMenu(menuName = "Scriptable Objects/Encounters/Penultimate Encounter")]
+public class PenultimateEncounter : Encounter
+{
+    [Header("Penultimate Encounter Flavor")]
+    [TextArea(3, 10)][SerializeField] string noclipResponse;
+    [TextArea(3, 10)][SerializeField] List<string> descriptions;
+    [SerializeField] int descriptionIndex = -1; //Serialized for debugging.
+    [SerializeField] bool isSetUp = false; //Serialized for debugging.
+
+    private void OnDisable()
+    {
+        isSetUp = false;
+    }
+
+    public override string GetDescription()
+    {
+        if(!isSetUp)
+        {
+            isSetUp = true;
+            descriptionIndex = -1;
+        }
+        descriptionIndex++;
+        descriptionIndex %= descriptions.Count;
+        return descriptions[descriptionIndex];
+    }
+
+    public override List<string> GetEncounterKeywords()
+    {
+        if (Random.Range(0, 1000) < 999) return null;
+        return base.GetEncounterKeywords();
+    }
+
+    public override bool IsEncounterKeyword(string[] tokens)
+    {
+        if (base.IsEncounterKeyword(tokens)) return true;
+        foreach (string token in tokens)
+        {
+            switch (token)
+            {
+                case "noclip":
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    public override string ParseEncounterKeywords(string[] tokens)
+    {
+        string baseRespone = base.ParseEncounterKeywords(tokens);
+        if(!baseRespone.Equals("Keyword not recognized.")) return baseRespone;
+        foreach (string token in tokens)
+        {
+            switch (token)
+            {
+                case "noclip":
+                    LeaveEncounter();
+                    return noclipResponse;
+            }
+        }
+
+        return $"Keyword not recognized.";
+    }
+
+    public override void LeaveEncounter()
+    {
+        isSetUp = false;
+        base.LeaveEncounter();
+    }
+}

--- a/Assets/Scripts/Point Of Interest/Encounters/PenultimateEncounter.cs.meta
+++ b/Assets/Scripts/Point Of Interest/Encounters/PenultimateEncounter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47e5bbc22f217284b9bebe27a1d91c45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Point Of Interest/Encounters/TrapEncounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/TrapEncounter.cs
@@ -20,7 +20,7 @@ public class TrapEncounter : Encounter, Waiter
     [SerializeField] string failureResponse;
     [TextArea(3, 10)]
     [SerializeField] string successResponse;
-    bool isSetUp = false;
+    [SerializeField] bool isSetUp = false;
 
     private void OnDisable()
     {

--- a/Assets/Scripts/Point Of Interest/Encounters/WizardEncounter.cs
+++ b/Assets/Scripts/Point Of Interest/Encounters/WizardEncounter.cs
@@ -1,0 +1,147 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// WizardEncounter is a noncombat <see cref="Encounter"/>
+/// Combines the Orb Room and Wizard from design doc.
+/// The wizard offers the player to chant in order to stare into the orb.
+/// If the player fails the chant, they take damage to health and stats.
+/// If the player succeeds the chant, they learn Foresight.
+/// If the player has tobacco, they can skip the chant and stare into the orb.
+/// </summary>
+[CreateAssetMenu(menuName = "Scriptable Objects/Encounters/Wizard Encounter")]
+public class WizardEncounter : Encounter, Waiter
+{
+    [Header("Wizard Flavor")]
+    [SerializeField] float chantWait = 3f;
+    [TextArea(3, 10)][SerializeField] string chantText;
+    [TextArea(3, 10)][SerializeField] string ignoreText;
+    [TextArea(3, 10)][SerializeField] string smokeText;
+    [TextArea(3, 10)][SerializeField] string chantPassText;
+    [TextArea(3, 10)][SerializeField] string chantFailText;
+
+    [Header("Wizard Punishment")]
+    [SerializeField] int speedLost = 10;
+    [SerializeField] int typingSpeedLost = 5;
+    [SerializeField] int damage = 10;
+    public override void CompleteMinigame(MinigameStatus gameResult)
+    {
+        switch (gameResult)
+        {
+            case MinigameStatus.MISSBUMP:
+            case MinigameStatus.LOST:
+                ChantFail();
+                break;
+            case MinigameStatus.FISTBUMP:
+            case MinigameStatus.WIN:
+                ChantPass();
+                break;
+            default:
+                TextOutput.instance.Print($"Unknown game status {gameResult}");
+                break;
+        }
+    }
+
+    private void ChantPass()
+    {
+        TextOutput.instance.Print(chantPassText);
+        Foresight();
+        //TODO: Here, I'd give the player the foresight cheat.
+        LeaveEncounter();
+    }
+
+    /// <summary>
+    /// Lists the encounters of all future routes.
+    /// </summary>
+    private void Foresight()
+    {
+        List<Route> foresight = GameManager.instance.GetCurrentPOIRoutes();
+        foreach(Route route in foresight)
+        {
+            PointOfInterest destination = route.GetDestination();
+            string futureEncounterName = destination.HasEncounter() ?
+                destination.GetEncounter().GetEncounterName() :
+                "nothing";
+            TextOutput.instance.Print($"To the {route.GetDirection()}, there is {futureEncounterName}.");
+        }
+    }
+
+    private void ChantFail()
+    {
+        TextOutput.instance.Print(chantFailText);
+        
+        //I could change these to the exact punishments in the doc, but these are the ones that are currently implemented and we do not have a lot of time.
+        PlayerStats.instance.DecreaseSpeed(speedLost);
+        PlayerStats.instance.DecreaseTypingSpeed(typingSpeedLost);
+        PlayerStats.instance.TakeDamage(damage);
+        LeaveEncounter();
+    }
+
+    public override bool IsEncounterKeyword(string[] tokens)
+    {
+        if(base.IsEncounterKeyword(tokens)) return true;
+        foreach (string token in tokens)
+        {
+            switch (token)
+            {
+                case "chant":
+                case "pass":
+                case "smoke":
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    public override string ParseEncounterKeywords(string[] tokens)
+    {
+        string baseResponse = base.ParseEncounterKeywords(tokens);
+        if(!baseResponse.Equals("Keyword not recognized.")) return baseResponse;
+        foreach (string token in tokens)
+        {
+            switch (token)
+            {
+                case "chant":
+                    return Chant();
+                case "pass":
+                    return Pass();
+                case "smoke":
+                    return Smoke();
+            }
+        }
+
+        return $"Keyword not recognized.";
+    }
+
+    private string Chant()
+    {
+        Wait.instance.WaitForSeconds(chantWait, this);
+        return chantText;
+    }
+
+    private string Pass()
+    {
+        LeaveEncounter();
+        return ignoreText;
+    }
+
+    private string Smoke()
+    {
+        //if (boofs > 0)
+        //{
+            TextOutput.instance.Print(smokeText);
+            ChantPass();
+        //}
+        //else
+        //{
+        //    TextOutput.instance.Print("You have nothing to smoke.");
+        //}
+        return null;
+    }
+
+    public void WaitComplete()
+    {
+        StartMinigame();
+    }
+}

--- a/Assets/Scripts/Point Of Interest/Encounters/WizardEncounter.cs.meta
+++ b/Assets/Scripts/Point Of Interest/Encounters/WizardEncounter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8010927fc9b56904d84eaf376e5bc19e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Point Of Interest/PointOfInterest.cs
+++ b/Assets/Scripts/Point Of Interest/PointOfInterest.cs
@@ -86,6 +86,20 @@ public class PointOfInterest : ScriptableObject
         return encounter; 
     }
 
+    /// <summary>
+    /// Gets all of the POI's keywords to be shown to the player.
+    /// </summary>
+    /// <returns>List of keywords.</returns>
+    public List<string> GetPOIKeywords()
+    {
+        List<string> response = null;
+        if (encounter != null) response = encounter.GetEncounterKeywords();
+        if (response == null) response = new List<string>();
+
+        response.Add("search");
+
+        return response;
+    }
 
     /// <summary>
     /// Checks if tokens contains a keyword for POI's <see cref="Encounter"/>.


### PR DESCRIPTION
There is a new help command. When the player types "help," they are now shown their available keywords. It works by having a list persist from the Encounter all the way to the GameManager. Only the keywords in the Encounter are easily changeable. The keywords in the POI and GameManager are hard coded. I also omitted cheat codes and other specific keywords in order to not handhold the player completely.

I also added the wizard encounter. The wizard will ask the player if they want to chant with them. If the player says yes, they are put through a minigame. If they succeed, they get to know what encounters are in the adjacent POIs. If they fail, the take some damage and lower some stats. You can also smoke with the wizard which skips the chanting minigame.

I also created the penultimate encounter. All it is is a fake "dead end" to the player. They eventually need to type "noclip" which then they are allowed to leave the encounter and progress to the final room (hence the name). It was based on the fake out ending we came up with in the original pitch.

I made some slice of life improvements to the encounters. It's more easy to tell when a horse is evil after petting it. Also, keywords are more emphasized in encounters' descriptions.

I also shortened all the floors as wanted. Removed about 3-4 layers per floor. Now the player only goes through about 6 rooms per floor, 19 rooms in total. Since there are 3 empty end rooms, 3 empty starting rooms, and 1 fake out dead end with the penultimate encounter, the player only goes through about 12 randomly generated encounters.